### PR TITLE
Move Input Display to Grid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdk 21
         targetSdk 32
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/app/src/main/cpp/jni/grid-jni.cpp
+++ b/app/src/main/cpp/jni/grid-jni.cpp
@@ -85,3 +85,9 @@ Java_app_notwordle_objects_Grid_nativeGetSpace(JNIEnv *env, jobject thiz, jlong 
     // convert C++ object to
     return (jlong)&space;
 }
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_app_notwordle_objects_Grid_nativeCurrentRow(JNIEnv *env, jobject thiz, jlong p_native_ptr) {
+    return ((Grid*)p_native_ptr)->CurrentRow();
+}

--- a/app/src/main/java/app/notwordle/GameActivity.kt
+++ b/app/src/main/java/app/notwordle/GameActivity.kt
@@ -48,8 +48,8 @@ class GameActivity : AppCompatActivity() {
         gridView = GridView(this, gameLayout)
         gridView.generateGrid(grid)
 
-        // create input by allowing user to write in text and enter it
-        // TODO: change this to write type user guess into Spaces
+        // input is typed into a hidden EditText that the Grid can examine to update
+        // its Spaces accordingly
         val inputLayout = findViewById<LinearLayout>(R.id.input_layout)
         this.input = EditText(this)
         input.visibility = EditText.GONE

--- a/app/src/main/java/app/notwordle/GameActivity.kt
+++ b/app/src/main/java/app/notwordle/GameActivity.kt
@@ -59,6 +59,7 @@ class GameActivity : AppCompatActivity() {
 
         keyboard = findViewById(R.id.keyboard)
         keyboard.setInputConnection(ic)
+        keyboard.maxInputSize = wordSize
 
         val enterBtn = keyboard.keys[keyboard.getButtonIndex("ent")]
         enterBtn!!.setOnClickListener {

--- a/app/src/main/java/app/notwordle/GameActivity.kt
+++ b/app/src/main/java/app/notwordle/GameActivity.kt
@@ -20,6 +20,7 @@ class GameActivity : AppCompatActivity() {
     var curCol: Int = 0
     lateinit var gridView: GridView
     lateinit var keyboard: GameKeyboard
+    lateinit var input: EditText
 
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,7 +51,8 @@ class GameActivity : AppCompatActivity() {
         // create input by allowing user to write in text and enter it
         // TODO: change this to write type user guess into Spaces
         val inputLayout = findViewById<LinearLayout>(R.id.input_layout)
-        val input = EditText(this)
+        this.input = EditText(this)
+        input.visibility = EditText.GONE
         input.hint = "enter input..."
         inputLayout.addView(input)
         input.setRawInputType(InputType.TYPE_CLASS_TEXT)
@@ -60,6 +62,16 @@ class GameActivity : AppCompatActivity() {
         keyboard = findViewById(R.id.keyboard)
         keyboard.setInputConnection(ic)
         keyboard.maxInputSize = wordSize
+        keyboard.gameCallback = {
+            val curTxt = input.text
+            val curRow = game.getGrid().CurrentRow()
+
+            for(col in 0 until wordSize) {
+                val letter : String = if (col < curTxt.length) curTxt[col].uppercase() else '-'.toString()
+                println("updated grid at [$curRow, $col] with '$letter'")
+                gridView.updateSpace(curRow, col, letter)
+            }
+        }
 
         val enterBtn = keyboard.keys[keyboard.getButtonIndex("ent")]
         enterBtn!!.setOnClickListener {

--- a/app/src/main/java/app/notwordle/GameKeyboard.kt
+++ b/app/src/main/java/app/notwordle/GameKeyboard.kt
@@ -27,7 +27,8 @@ class GameKeyboard @JvmOverloads constructor(
     private var inputConnection: InputConnection? = null
 
     // upper limit of character inputs, reject inputs after this (except special keys)
-    var maxInputSize : Int = 0;
+    var maxInputSize : Int = 0
+    var gameCallback : () -> Unit = {}
 
     private fun init(context: Context, attrs: AttributeSet?) {
         LayoutInflater.from(context).inflate(R.layout.keyboard, this, true)
@@ -141,6 +142,8 @@ class GameKeyboard @JvmOverloads constructor(
                 inputConnection!!.commitText(value, 1)
             }
         }
+        gameCallback()
+
     }
 
     fun setInputConnection(ic: InputConnection?) {

--- a/app/src/main/java/app/notwordle/GameKeyboard.kt
+++ b/app/src/main/java/app/notwordle/GameKeyboard.kt
@@ -7,6 +7,7 @@ import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.LayoutInflater
 import android.view.View
+import android.view.inputmethod.ExtractedTextRequest
 import android.view.inputmethod.InputConnection
 import android.widget.Button
 import android.widget.LinearLayout
@@ -24,7 +25,10 @@ class GameKeyboard @JvmOverloads constructor(
     private val keyValues = SparseArray<String>()
     
     private var inputConnection: InputConnection? = null
-    
+
+    // upper limit of character inputs, reject inputs after this (except special keys)
+    var maxInputSize : Int = 0;
+
     private fun init(context: Context, attrs: AttributeSet?) {
         LayoutInflater.from(context).inflate(R.layout.keyboard, this, true)
 
@@ -131,8 +135,11 @@ class GameKeyboard @JvmOverloads constructor(
                 inputConnection!!.commitText("", 1)
             }
         } else {
-            val value = keyValues[view.id]
-            inputConnection!!.commitText(value, 1)
+            val etxt = inputConnection!!.getExtractedText(ExtractedTextRequest(), 0);
+            if (etxt.text.length < maxInputSize) {
+                val value = keyValues[view.id]
+                inputConnection!!.commitText(value, 1)
+            }
         }
     }
 

--- a/app/src/main/java/app/notwordle/objects/Grid.kt
+++ b/app/src/main/java/app/notwordle/objects/Grid.kt
@@ -42,6 +42,10 @@ class Grid() {
         return Space(nativeGetSpace(nativePtr, row, col))
     }
 
+    fun CurrentRow() : Int {
+        return nativeCurrentRow(nativePtr);
+    }
+
     private external fun createNativeGrid(word_size: Int) : Long
     private external fun destroyNativeInstance(p_native_ptr : Long)
     private external fun nativeToString(p_native_ptr: Long) : String
@@ -50,6 +54,7 @@ class Grid() {
     private external fun nativeIncrementGuess(p_native_ptr: Long) : Boolean
     private external fun nativeGetGridDimensions(p_native_ptr: Long) : Pair<Int, Int>
     private external fun nativeGetSpace(p_native_ptr: Long, row: Int, col: Int) : Long
+    private external fun nativeCurrentRow(p_native_ptr: Long) : Int
 }
 
 class GridView(context: Context, var parent: LinearLayout) : View(context) {


### PR DESCRIPTION
The original input for this game was displayed through an EditText box shown under the keyboard. The user would then select 'Enter' to see the Grid updated with that input. This change will hide that the EditText and instead update the Grid with each key press on the keyboard.